### PR TITLE
Convert SwerveModule to an interface with subclasses

### DIFF
--- a/src/main/java/frc/robot/SwerveModule.java
+++ b/src/main/java/frc/robot/SwerveModule.java
@@ -1,116 +1,22 @@
 package frc.robot;
 
-import com.ctre.phoenix6.controls.DutyCycleOut;
-import com.ctre.phoenix6.controls.PositionVoltage;
-import com.ctre.phoenix6.controls.VelocityVoltage;
-import com.ctre.phoenix6.hardware.CANcoder;
-import com.ctre.phoenix6.hardware.TalonFX;
-
-
-import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 
-import frc.lib.math.Conversions;
-import frc.lib.util.SwerveModuleConstants;
+/**
+ * Interface containing behavior needed to control a swerve module.
+ *
+ * One swerve module is a steering motor and a drive motor working together.
+ * The module includes the encoders for sensing the rotation of the steering
+ * and driving motors, whether those encoders are included in the motor
+ * controller or a distinct, standalone unit.
+ */
+public interface SwerveModule {
+    void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop);
+    void resetToAbsolute();
 
-import com.revrobotics.CANSparkMax;
-//import com.revrobotics.RelativeEncoder;
-import com.revrobotics.SparkPIDController;
-//import com.revrobotics.CANSparkLowLevel;
-import com.revrobotics.CANSparkLowLevel.MotorType;
-
-//import com.revrobotics.CANSparkMax;
-
-//import edu.wpi.first.math.controller.SimpleMotorFeedforward;
-//import edu.wpi.first.math.geometry.Rotation2d;
-//import edu.wpi.first.math.kinematics.SwerveModulePosition;
-//import edu.wpi.first.math.kinematics.SwerveModuleState;
-//import frc.lib.math.Conversions;
-//import frc.lib.util.SwerveModuleConstants;
-
-//import com.revrobotics.SparkPIDController;
-
-public class SwerveModule {
-    public int moduleNumber;
-    private Rotation2d angleOffset;
-
-    private CANSparkMax mAngleMotor;
-    private TalonFX mDriveMotor;
-    private CANcoder angleEncoder;
-
-    private final SimpleMotorFeedforward driveFeedForward = new SimpleMotorFeedforward(Constants.Swerve.driveKS, Constants.Swerve.driveKV, Constants.Swerve.driveKA);
-
-    /* drive motor control requests */
-    private final DutyCycleOut driveDutyCycle = new DutyCycleOut(0);
-    private final VelocityVoltage driveVelocity = new VelocityVoltage(0);
-
-    /* angle motor control requests */
-    private final PositionVoltage anglePosition = new PositionVoltage(0);
-
-    public SwerveModule(int moduleNumber, SwerveModuleConstants moduleConstants){
-        this.moduleNumber = moduleNumber;
-        this.angleOffset = moduleConstants.angleOffset;
-        
-        /* Angle Encoder Config */
-        angleEncoder = new CANcoder(moduleConstants.cancoderID);
-        angleEncoder.getConfigurator().apply(Robot.ctreConfigs.swerveCANcoderConfig);
-
-        /* Angle Motor Config */
-        mAngleMotor = new CANSparkMax(moduleConstants.angleMotorID, MotorType.kBrushless);
-        resetToAbsolute();
-
-        /* Drive Motor Config */
-        mDriveMotor = new TalonFX(moduleConstants.driveMotorID);
-        mDriveMotor.getConfigurator().apply(Robot.ctreConfigs.swerveDriveFXConfig);
-        mDriveMotor.getConfigurator().setPosition(0.0);
-    }
-
-    public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop){
-        desiredState = SwerveModuleState.optimize(desiredState, getState().angle); 
-        SparkPIDController pidController = mAngleMotor.getPIDController();
-        pidController.setReference(desiredState.angle.getRotations(),CANSparkMax.ControlType.kPosition);
-        //mAngleMotor.setControl(anglePosition.withPosition(desiredState.angle.getRotations()));
-        setSpeed(desiredState, isOpenLoop);
-    }
-
-    private void setSpeed(SwerveModuleState desiredState, boolean isOpenLoop){
-        if(isOpenLoop){
-            driveDutyCycle.Output = desiredState.speedMetersPerSecond / Constants.Swerve.maxSpeed;
-            mDriveMotor.setControl(driveDutyCycle);
-        }
-        else {
-            driveVelocity.Velocity = Conversions.MPSToRPS(desiredState.speedMetersPerSecond, Constants.Swerve.wheelCircumference);
-            driveVelocity.FeedForward = driveFeedForward.calculate(desiredState.speedMetersPerSecond);
-            mDriveMotor.setControl(driveVelocity);
-        }
-    }
-
-    public Rotation2d getCANcoder(){
-        return Rotation2d.fromRotations(angleEncoder.getAbsolutePosition().getValue());
-    }
-
-    public void resetToAbsolute(){
-        double absolutePosition = getCANcoder().getRotations() - angleOffset.getRotations();
-
-        SparkPIDController pidController = mAngleMotor.getPIDController();
-        pidController.setReference(absolutePosition,CANSparkMax.ControlType.kPosition);
-
-        //mAngleMotor.setPosition(absolutePosition);
-    }
-
-    public SwerveModuleState getState(){
-        return new SwerveModuleState(            
-            Conversions.RPSToMPS(mDriveMotor.getVelocity().getValue(), Constants.Swerve.wheelCircumference), 
-            Rotation2d.fromRotations(mAngleMotor.getEncoder().getPosition()) //mAngleMotor.getPIDController().get)
-        );
-    }
-
-    public SwerveModulePosition getPosition(){
-        return new SwerveModulePosition(
-            Conversions.rotationsToMeters(mDriveMotor.getPosition().getValue(), Constants.Swerve.wheelCircumference), 
-            Rotation2d.fromRotations(mDriveMotor.getPosition().getValue())
-        );
-    }
+    Rotation2d getRotation();
+    SwerveModulePosition getPosition();
+    SwerveModuleState getState();
 }

--- a/src/main/java/frc/robot/SwerveModuleTalonNeo.java
+++ b/src/main/java/frc/robot/SwerveModuleTalonNeo.java
@@ -1,0 +1,106 @@
+package frc.robot;
+
+import com.ctre.phoenix6.controls.DutyCycleOut;
+import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.hardware.CANcoder;
+import com.ctre.phoenix6.hardware.TalonFX;
+
+
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+
+import frc.lib.math.Conversions;
+import frc.lib.util.SwerveModuleConstants;
+
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.SparkPIDController;
+import com.revrobotics.CANSparkLowLevel.MotorType;
+
+/**
+ * Swerve Module using a TalonFX for Drive and a CANSparkMax for Steering
+ */
+public class SwerveModuleTalonNeo implements SwerveModule {
+    private Rotation2d angleOffset;
+
+    private CANSparkMax mAngleMotor;
+    private TalonFX mDriveMotor;
+    private CANcoder angleEncoder;
+
+    private final SimpleMotorFeedforward driveFeedForward = new SimpleMotorFeedforward(Constants.Swerve.driveKS, Constants.Swerve.driveKV, Constants.Swerve.driveKA);
+
+    /* drive motor control requests */
+    private final DutyCycleOut driveDutyCycle = new DutyCycleOut(0);
+    private final VelocityVoltage driveVelocity = new VelocityVoltage(0);
+
+    /* angle motor control requests */
+    private final PositionVoltage anglePosition = new PositionVoltage(0);
+
+    public SwerveModuleTalonNeo(SwerveModuleConstants moduleConstants) {
+        this.angleOffset = moduleConstants.angleOffset;
+        
+        /* Angle Encoder Config */
+        angleEncoder = new CANcoder(moduleConstants.cancoderID);
+        angleEncoder.getConfigurator().apply(Robot.ctreConfigs.swerveCANcoderConfig);
+
+        /* Angle Motor Config */
+        mAngleMotor = new CANSparkMax(moduleConstants.angleMotorID, MotorType.kBrushless);
+        resetToAbsolute();
+
+        /* Drive Motor Config */
+        mDriveMotor = new TalonFX(moduleConstants.driveMotorID);
+        mDriveMotor.getConfigurator().apply(Robot.ctreConfigs.swerveDriveFXConfig);
+        mDriveMotor.getConfigurator().setPosition(0.0);
+    }
+
+    @Override
+    public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop){
+        desiredState = SwerveModuleState.optimize(desiredState, getState().angle); 
+        SparkPIDController pidController = mAngleMotor.getPIDController();
+        pidController.setReference(desiredState.angle.getRotations(),CANSparkMax.ControlType.kPosition);
+        //mAngleMotor.setControl(anglePosition.withPosition(desiredState.angle.getRotations()));
+        setSpeed(desiredState, isOpenLoop);
+    }
+
+    @Override
+    public Rotation2d getRotation(){
+        return Rotation2d.fromRotations(angleEncoder.getAbsolutePosition().getValue());
+    }
+
+    public void resetToAbsolute(){
+        double absolutePosition = getRotation().getRotations() - angleOffset.getRotations();
+
+        SparkPIDController pidController = mAngleMotor.getPIDController();
+        pidController.setReference(absolutePosition,CANSparkMax.ControlType.kPosition);
+
+        //mAngleMotor.setPosition(absolutePosition);
+    }
+
+    public SwerveModuleState getState(){
+        return new SwerveModuleState(            
+            Conversions.RPSToMPS(mDriveMotor.getVelocity().getValue(), Constants.Swerve.wheelCircumference), 
+            Rotation2d.fromRotations(mAngleMotor.getEncoder().getPosition()) //mAngleMotor.getPIDController().get)
+        );
+    }
+
+    public SwerveModulePosition getPosition(){
+        return new SwerveModulePosition(
+            Conversions.rotationsToMeters(mDriveMotor.getPosition().getValue(), Constants.Swerve.wheelCircumference), 
+            Rotation2d.fromRotations(mDriveMotor.getPosition().getValue())
+        );
+    }
+
+    private void setSpeed(SwerveModuleState desiredState, boolean isOpenLoop){
+        if(isOpenLoop){
+            driveDutyCycle.Output = desiredState.speedMetersPerSecond / Constants.Swerve.maxSpeed;
+            mDriveMotor.setControl(driveDutyCycle);
+        }
+        else {
+            driveVelocity.Velocity = Conversions.MPSToRPS(desiredState.speedMetersPerSecond, Constants.Swerve.wheelCircumference);
+            driveVelocity.FeedForward = driveFeedForward.calculate(desiredState.speedMetersPerSecond);
+            mDriveMotor.setControl(driveVelocity);
+        }
+    }
+}

--- a/src/main/java/frc/robot/SwerveModuleTalonTalon.java
+++ b/src/main/java/frc/robot/SwerveModuleTalonTalon.java
@@ -1,0 +1,97 @@
+package frc.robot;
+
+import com.ctre.phoenix6.controls.DutyCycleOut;
+import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.hardware.CANcoder;
+import com.ctre.phoenix6.hardware.TalonFX;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import frc.lib.math.Conversions;
+import frc.lib.util.SwerveModuleConstants;
+
+/**
+ * Swerve Module using a TalonFX for both Drive and Steering
+ */
+public class SwerveModuleTalonTalon implements SwerveModule {
+    private Rotation2d angleOffset;
+
+    private TalonFX mAngleMotor;
+    private TalonFX mDriveMotor;
+    private CANcoder angleEncoder;
+
+    private final SimpleMotorFeedforward driveFeedForward = new SimpleMotorFeedforward(Constants.Swerve.driveKS, Constants.Swerve.driveKV, Constants.Swerve.driveKA);
+
+    /* drive motor control requests */
+    private final DutyCycleOut driveDutyCycle = new DutyCycleOut(0);
+    private final VelocityVoltage driveVelocity = new VelocityVoltage(0);
+
+    /* angle motor control requests */
+    private final PositionVoltage anglePosition = new PositionVoltage(0);
+
+    public SwerveModuleTalonTalon(SwerveModuleConstants moduleConstants) {
+        this.angleOffset = moduleConstants.angleOffset;
+
+        /* Angle Encoder Config */
+        angleEncoder = new CANcoder(moduleConstants.cancoderID);
+        angleEncoder.getConfigurator().apply(Robot.ctreConfigs.swerveCANcoderConfig);
+
+        /* Angle Motor Config */
+        mAngleMotor = new TalonFX(moduleConstants.angleMotorID);
+        mAngleMotor.getConfigurator().apply(Robot.ctreConfigs.swerveAngleFXConfig);
+        resetToAbsolute();
+
+        /* Drive Motor Config */
+        mDriveMotor = new TalonFX(moduleConstants.driveMotorID);
+        mDriveMotor.getConfigurator().apply(Robot.ctreConfigs.swerveDriveFXConfig);
+        mDriveMotor.getConfigurator().setPosition(0.0);
+    }
+
+    @Override
+    public void setDesiredState(SwerveModuleState desiredState, boolean isOpenLoop) {
+        desiredState = SwerveModuleState.optimize(desiredState, getState().angle);
+        mAngleMotor.setControl(anglePosition.withPosition(desiredState.angle.getRotations()));
+        setSpeed(desiredState, isOpenLoop);
+    }
+
+    @Override
+    public Rotation2d getRotation() {
+        return Rotation2d.fromRotations(angleEncoder.getAbsolutePosition().getValue());
+    }
+
+    @Override
+    public void resetToAbsolute() {
+        double absolutePosition = getRotation().getRotations() - angleOffset.getRotations();
+        mAngleMotor.setPosition(absolutePosition);
+    }
+
+    @Override
+    public SwerveModuleState getState() {
+        return new SwerveModuleState(
+                Conversions.RPSToMPS(mDriveMotor.getVelocity().getValue(), Constants.Swerve.wheelCircumference),
+                Rotation2d.fromRotations(mAngleMotor.getPosition().getValue())
+        );
+    }
+
+    @Override
+    public SwerveModulePosition getPosition() {
+        return new SwerveModulePosition(
+                Conversions.rotationsToMeters(mDriveMotor.getPosition().getValue(), Constants.Swerve.wheelCircumference),
+                Rotation2d.fromRotations(mAngleMotor.getPosition().getValue())
+        );
+    }
+
+    private void setSpeed(SwerveModuleState desiredState, boolean isOpenLoop) {
+        if(isOpenLoop){
+            driveDutyCycle.Output = desiredState.speedMetersPerSecond / Constants.Swerve.maxSpeed;
+            mDriveMotor.setControl(driveDutyCycle);
+        }
+        else {
+            driveVelocity.Velocity = Conversions.MPSToRPS(desiredState.speedMetersPerSecond, Constants.Swerve.wheelCircumference);
+            driveVelocity.FeedForward = driveFeedForward.calculate(desiredState.speedMetersPerSecond);
+            mDriveMotor.setControl(driveVelocity);
+        }
+    }
+}

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems;
 
 import frc.robot.SwerveModule;
+import frc.robot.SwerveModuleTalonNeo;
 import frc.robot.Constants;
 
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -23,18 +24,26 @@ public class Swerve extends SubsystemBase {
     public SwerveModule[] mSwerveMods;
     public Pigeon2 gyro;
 
+    /**
+     * Default constructor uses SwerveModuleTalonNeo
+     */
     public Swerve() {
+        this(new SwerveModule[] {
+            new SwerveModuleTalonNeo(Constants.Swerve.Mod0.constants),
+            new SwerveModuleTalonNeo(Constants.Swerve.Mod1.constants),
+            new SwerveModuleTalonNeo(Constants.Swerve.Mod2.constants),
+            new SwerveModuleTalonNeo(Constants.Swerve.Mod3.constants)
+        });
+    }
+
+    /**
+     * Constructor that allows custom SwerveModules
+     */
+    public Swerve(SwerveModule[] modules) {
+        this.mSwerveMods = modules;
         gyro = new Pigeon2(Constants.Swerve.pigeonID);
         gyro.getConfigurator().apply(new Pigeon2Configuration());
         gyro.setYaw(0);
-
-        mSwerveMods = new SwerveModule[] {
-            new SwerveModule(0, Constants.Swerve.Mod0.constants),
-            new SwerveModule(1, Constants.Swerve.Mod1.constants),
-            new SwerveModule(2, Constants.Swerve.Mod2.constants),
-            new SwerveModule(3, Constants.Swerve.Mod3.constants)
-        };
-
         swerveOdometry = new SwerveDriveOdometry(Constants.Swerve.swerveKinematics, getGyroYaw(), getModulePositions());
     }
 
@@ -54,32 +63,36 @@ public class Swerve extends SubsystemBase {
                                 );
         SwerveDriveKinematics.desaturateWheelSpeeds(swerveModuleStates, Constants.Swerve.maxSpeed);
 
-        for(SwerveModule mod : mSwerveMods){
-            mod.setDesiredState(swerveModuleStates[mod.moduleNumber], isOpenLoop);
+        for(int i = 0; i < mSwerveMods.length; i++) {
+            SwerveModule mod = mSwerveMods[i];
+            mod.setDesiredState(swerveModuleStates[i], isOpenLoop);
         }
-    }    
+    }
 
     /* Used by SwerveControllerCommand in Auto */
     public void setModuleStates(SwerveModuleState[] desiredStates) {
         SwerveDriveKinematics.desaturateWheelSpeeds(desiredStates, Constants.Swerve.maxSpeed);
-        
-        for(SwerveModule mod : mSwerveMods){
-            mod.setDesiredState(desiredStates[mod.moduleNumber], false);
+
+        for(int i = 0; i < mSwerveMods.length; i++) {
+            SwerveModule mod = mSwerveMods[i];
+            mod.setDesiredState(desiredStates[i], false);
         }
     }
 
-    public SwerveModuleState[] getModuleStates(){
+    public SwerveModuleState[] getModuleStates() {
         SwerveModuleState[] states = new SwerveModuleState[4];
-        for(SwerveModule mod : mSwerveMods){
-            states[mod.moduleNumber] = mod.getState();
+        for(int i = 0; i < mSwerveMods.length; i++) {
+            SwerveModule mod = mSwerveMods[i];
+            states[i] = mod.getState();
         }
         return states;
     }
 
-    public SwerveModulePosition[] getModulePositions(){
+    public SwerveModulePosition[] getModulePositions() {
         SwerveModulePosition[] positions = new SwerveModulePosition[4];
-        for(SwerveModule mod : mSwerveMods){
-            positions[mod.moduleNumber] = mod.getPosition();
+        for(int i = 0; i < mSwerveMods.length; i++) {
+            SwerveModule mod = mSwerveMods[i];
+            positions[i] = mod.getPosition();
         }
         return positions;
     }
@@ -96,11 +109,11 @@ public class Swerve extends SubsystemBase {
         return getPose().getRotation();
     }
 
-    public void setHeading(Rotation2d heading){
+    public void setHeading(Rotation2d heading) {
         swerveOdometry.resetPosition(getGyroYaw(), getModulePositions(), new Pose2d(getPose().getTranslation(), heading));
     }
 
-    public void zeroHeading(){
+    public void zeroHeading() {
         swerveOdometry.resetPosition(getGyroYaw(), getModulePositions(), new Pose2d(getPose().getTranslation(), new Rotation2d()));
     }
 
@@ -108,8 +121,9 @@ public class Swerve extends SubsystemBase {
         return Rotation2d.fromDegrees(gyro.getYaw().getValue());
     }
 
-    public void resetModulesToAbsolute(){
-        for(SwerveModule mod : mSwerveMods){
+    public void resetModulesToAbsolute() {
+        for(int i = 0; i < mSwerveMods.length; i++) {
+            SwerveModule mod = mSwerveMods[i];
             mod.resetToAbsolute();
         }
     }
@@ -118,10 +132,11 @@ public class Swerve extends SubsystemBase {
     public void periodic(){
         swerveOdometry.update(getGyroYaw(), getModulePositions());
 
-        for(SwerveModule mod : mSwerveMods){
-            SmartDashboard.putNumber("Mod " + mod.moduleNumber + " CANcoder", mod.getCANcoder().getDegrees());
-            SmartDashboard.putNumber("Mod " + mod.moduleNumber + " Angle", mod.getPosition().angle.getDegrees());
-            SmartDashboard.putNumber("Mod " + mod.moduleNumber + " Velocity", mod.getState().speedMetersPerSecond);    
+        for(int i = 0; i < mSwerveMods.length; i++) {
+            SwerveModule mod = mSwerveMods[i];
+            SmartDashboard.putNumber("Mod " + i + " CANcoder", mod.getRotation().getDegrees());
+            SmartDashboard.putNumber("Mod " + i + " Angle", mod.getPosition().angle.getDegrees());
+            SmartDashboard.putNumber("Mod " + i + " Velocity", mod.getState().speedMetersPerSecond);
         }
     }
 }


### PR DESCRIPTION
This should let us use differently-configured swerve modules in the Swerve subsystem. For example, the test robot uses TalonFX for both drive and steering, so we can construct a `Swerve` subsystem using the `SwerveModuleTalonTalon` subclass, and for the new robot that uses a TalonFX to drive and a Neo to steer, we can use `SwerveModuleTalonNeo` instead. If there are any other combinations of motors/controllers used in swerve modules, we can just implement another subclass of `SwerveModule`.